### PR TITLE
Update migration instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ to the require section of your `composer.json` file.
 Usage
 -----
 ```bash
- APPLICATION_ENV=development ./yii migrate/create install --migrationPath=@vendor/yii2-user-auth/migrations
+ APPLICATION_ENV=development ./yii migrate install --migrationPath=@vendor/cottacush/yii2-user-auth/migrations
 ```
 
 ## Security


### PR DESCRIPTION
This PR does two things:

1. It updates the instructions in the README to reflect that this library is now being installed via composer.
2. It corrects the mistake in the migration command, `create` instead `install`. 